### PR TITLE
Made startup code compatible with old and new versions of SDCC

### DIFF
--- a/BlinkLED/README.md
+++ b/BlinkLED/README.md
@@ -42,7 +42,7 @@ make run
 Edit the variables at the top of the Makefile to:
 - **DEVICE**: Use a different Padauk MCU (defaults to PFS154)
 - **F_CPU**: Use a different frequency for the system clock (defaults to 1MHz, i.e. IHRC/16)
-  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `_sdcc_external_startup()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
+  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `STARTUP_FUNCTION()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
   > The `AUTO_CALIBRATE_SYSCLOCK(vdd)` macro will install a placeholder for the correct internal oscillator (IHRC or ILRC) that the Easy PDK Programmer will use to calibrate to the desired frequency.
 - **TARGET_VDD_MV**: Use a different voltage while calibrating the internal oscillator (IHRC or ILRC) (defaults to 4000mV)
 - **TARGET_VDD**: Use a different voltage while the IC is operating (defaults to 4.0V)

--- a/BlinkLED/main.c
+++ b/BlinkLED/main.c
@@ -7,6 +7,7 @@
 
 #include <pdk/device.h>
 #include "auto_sysclock.h"
+#include "startup.h"
 #include "delay.h"
 
 // LED is placed on the PA4 pin (Port A, Bit 4) with a current sink configuration
@@ -33,7 +34,7 @@ void main() {
 }
 
 // Startup code - Setup/calibrate system clock
-unsigned char _sdcc_external_startup(void) {
+unsigned char STARTUP_FUNCTION(void) {
 
   // Initialize the system clock (CLKMD register) with the IHRC, ILRC, or EOSC clock source and correct divider.
   // The AUTO_INIT_SYSCLOCK() macro uses F_CPU (defined in the Makefile) to choose the IHRC or ILRC clock source and divider.

--- a/BlinkLED_WithIRQ/README.md
+++ b/BlinkLED_WithIRQ/README.md
@@ -50,7 +50,7 @@ make run
 Edit the variables at the top of the Makefile to:
 - **DEVICE**: Use a different Padauk MCU (defaults to PFS154)
 - **F_CPU**: Use a different frequency for the system clock (defaults to 1MHz, i.e. IHRC/16)
-  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `_sdcc_external_startup()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
+  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `STARTUP_FUNCTION()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
   > The `AUTO_CALIBRATE_SYSCLOCK(vdd)` macro will install a placeholder for the correct internal oscillator (IHRC or ILRC) that the Easy PDK Programmer will use to calibrate to the desired frequency.
 - **TARGET_VDD_MV**: Use a different voltage while calibrating the internal oscillator (IHRC or ILRC) (defaults to 4000mV)
 - **TARGET_VDD**: Use a different voltage while the IC is operating (defaults to 4.0V)

--- a/BlinkLED_WithIRQ/main.c
+++ b/BlinkLED_WithIRQ/main.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <pdk/device.h>
 #include "auto_sysclock.h"
+#include "startup.h"
 #include "millis.h"
 
 // Note: millis.h uses timer16 (T16) interrupts for timekeeping.
@@ -55,7 +56,7 @@ void main() {
 }
 
 // Startup code - Setup/calibrate system clock
-unsigned char _sdcc_external_startup(void) {
+unsigned char STARTUP_FUNCTION(void) {
 
   // Initialize the system clock (CLKMD register) with the IHRC, ILRC, or EOSC clock source and correct divider.
   // The AUTO_INIT_SYSCLOCK() macro uses F_CPU (defined in the Makefile) to choose the IHRC or ILRC clock source and divider.

--- a/FadeLED/README.md
+++ b/FadeLED/README.md
@@ -50,7 +50,7 @@ make run
 Edit the variables at the top of the Makefile to:
 - **DEVICE**: Use a different Padauk MCU (defaults to PFS154)
 - **F_CPU**: Use a different frequency for the system clock (defaults to 1MHz, i.e. IHRC/16)
-  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `_sdcc_external_startup()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
+  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `STARTUP_FUNCTION()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
   > The `AUTO_CALIBRATE_SYSCLOCK(vdd)` macro will install a placeholder for the correct internal oscillator (IHRC or ILRC) that the Easy PDK Programmer will use to calibrate to the desired frequency.
 - **TARGET_VDD_MV**: Use a different voltage while calibrating the internal oscillator (IHRC or ILRC) (defaults to 4000mV)
 - **TARGET_VDD**: Use a different voltage while the IC is operating (defaults to 4.0V)

--- a/FadeLED/main.c
+++ b/FadeLED/main.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <pdk/device.h>
 #include "auto_sysclock.h"
+#include "startup.h"
 #include "delay.h"
 
 #define PWM_MAX               255
@@ -82,7 +83,7 @@ void main() {
 }
 
 // Startup code - Setup/calibrate system clock
-unsigned char _sdcc_external_startup(void) {
+unsigned char STARTUP_FUNCTION(void) {
 
   // Initialize the system clock (CLKMD register) with the IHRC, ILRC, or EOSC clock source and correct divider.
   // The AUTO_INIT_SYSCLOCK() macro uses F_CPU (defined in the Makefile) to choose the IHRC or ILRC clock source and divider.

--- a/ReadButton_WriteLED/README.md
+++ b/ReadButton_WriteLED/README.md
@@ -55,7 +55,7 @@ make run
 Edit the variables at the top of the Makefile to:
 - **DEVICE**: Use a different Padauk MCU (defaults to PFS154)
 - **F_CPU**: Use a different frequency for the system clock (defaults to 1MHz, i.e. IHRC/16)
-  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `_sdcc_external_startup()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
+  > Note: The `AUTO_INIT_SYSCLOCK()` macro in the `STARTUP_FUNCTION()` method will automatically choose the correct internal oscillator (IHRC or ILRC) and clock divider based on the desired frequency.
   > The `AUTO_CALIBRATE_SYSCLOCK(vdd)` macro will install a placeholder for the correct internal oscillator (IHRC or ILRC) that the Easy PDK Programmer will use to calibrate to the desired frequency.
 - **TARGET_VDD_MV**: Use a different voltage while calibrating the internal oscillator (IHRC or ILRC) (defaults to 4000mV)
 - **TARGET_VDD**: Use a different voltage while the IC is operating (defaults to 4.0V)

--- a/ReadButton_WriteLED/main.c
+++ b/ReadButton_WriteLED/main.c
@@ -6,6 +6,7 @@
 
 #include <pdk/device.h>
 #include "auto_sysclock.h"
+#include "startup.h"
 #include "delay.h"
 
 // BTN is placed on the PA5 pin (Port A, Bit 5) with an active low configuration
@@ -44,7 +45,7 @@ void main() {
 }
 
 // Startup code - Setup/calibrate system clock
-unsigned char _sdcc_external_startup(void) {
+unsigned char STARTUP_FUNCTION(void) {
 
   // Initialize the system clock (CLKMD register) with the IHRC, ILRC, or EOSC clock source and correct divider.
   // The AUTO_INIT_SYSCLOCK() macro uses F_CPU (defined in the Makefile) to choose the IHRC or ILRC clock source and divider.

--- a/ReadButton_WriteSerial/main.c
+++ b/ReadButton_WriteSerial/main.c
@@ -6,6 +6,7 @@
 
 #include <pdk/device.h>
 #include "auto_sysclock.h"
+#include "startup.h"
 #include "serial.h"
 #include "delay.h"
 
@@ -55,7 +56,7 @@ void main() {
 }
 
 // Startup code - Setup/calibrate system clock
-unsigned char _sdcc_external_startup(void) {
+unsigned char STARTUP_FUNCTION(void) {
 
   // Initialize the system clock (CLKMD register) with the IHRC, ILRC, or EOSC clock source and correct divider.
   // The AUTO_INIT_SYSCLOCK() macro uses F_CPU (defined in the Makefile) to choose the IHRC or ILRC clock source and divider.

--- a/Serial_HelloWorld/main.c
+++ b/Serial_HelloWorld/main.c
@@ -6,6 +6,7 @@
 
 #include <pdk/device.h>
 #include "auto_sysclock.h"
+#include "startup.h"
 #include "serial.h"
 #include "delay.h"
 
@@ -35,7 +36,7 @@ void main() {
 }
 
 // Startup code - Setup/calibrate system clock
-unsigned char _sdcc_external_startup(void) {
+unsigned char STARTUP_FUNCTION(void) {
 
   // Initialize the system clock (CLKMD register) with the IHRC, ILRC, or EOSC clock source and correct divider.
   // The AUTO_INIT_SYSCLOCK() macro uses F_CPU (defined in the Makefile) to choose the IHRC or ILRC clock source and divider.

--- a/include/startup.h
+++ b/include/startup.h
@@ -1,0 +1,5 @@
+#if __SDCC_REVISION >= 13762
+#define STARTUP_FUNCTION __sdcc_external_startup
+#else
+#define STARTUP_FUNCTION _sdcc_external_startup
+#endif

--- a/include/startup.h
+++ b/include/startup.h
@@ -1,3 +1,5 @@
+// The name of the function that sdcc uses for startup changed.
+// This macro assigns the correct name to STARTUP_FUNCTION based on the sdcc version.
 #if __SDCC_REVISION >= 13762
 #define STARTUP_FUNCTION __sdcc_external_startup
 #else


### PR DESCRIPTION
This should address this bug: https://github.com/free-pdk/free-pdk-examples/issues/9

This PR uses a macro the define the correct name for the external startup version, and updates the examples to use that macro.